### PR TITLE
Fix IEnumerable<T> resolution

### DIFF
--- a/src/TinyIoC/TinyIoC.cs
+++ b/src/TinyIoC/TinyIoC.cs
@@ -2939,7 +2939,7 @@ namespace TinyIoC
 #endif
         private object GetIEnumerableRequest(Type type)
         {
-            var genericResolveAllMethod = this.GetType().GetGenericMethod(BindingFlags.Public | BindingFlags.Instance, "ResolveAll", type.GetGenericArguments(), new Type[] { });
+            var genericResolveAllMethod = this.GetType().GetGenericMethod(BindingFlags.Public | BindingFlags.Instance, "ResolveAll", type.GetGenericArguments(), new[] { typeof(bool) });
 
 //#if GETPARAMETERS_OPEN_GENERICS
 //            // Using MakeGenericMethod (slow) because we need to
@@ -2960,7 +2960,7 @@ namespace TinyIoC
 
 //            var genericResolveAllMethod = resolveAllMethods.First();
 //#endif
-            return genericResolveAllMethod.Invoke(this, new object[] { });
+            return genericResolveAllMethod.Invoke(this, new object[] { false });
         }
 
         private bool CanConstruct(ConstructorInfo ctor, NamedParameterOverloads parameters, ResolveOptions options)


### PR DESCRIPTION
Don't include unnamed T registrations when resolving IEnumerable<T>.
