### PR TITLE
Type registration hash code cache

### DIFF
--- a/src/TinyIoC/TinyIoC.cs
+++ b/src/TinyIoC/TinyIoC.cs
@@ -2598,6 +2598,8 @@ namespace TinyIoC
         #region Type Registrations
         public sealed class TypeRegistration
         {
+            private int? _hashCode;
+
             public Type Type { get; private set; }
             public string Name { get; private set; }
 
@@ -2630,7 +2632,11 @@ namespace TinyIoC
 
             public override int GetHashCode()
             {
-                return String.Format("{0}|{1}", Type.FullName, Name).GetHashCode();
+                if (_hashCode != null)
+                    return _hashCode.Value;
+
+                _hashCode = String.Concat(Type.FullName, "|", Name).GetHashCode();
+                return _hashCode.Value;
             }
         }
         private readonly SafeDictionary<TypeRegistration, ObjectFactoryBase> _RegisteredTypes;


### PR DESCRIPTION
Only calculate the HashCode once for the lifetime of a TypeRegistration instance.  This tweak increases throughput of my test app with 100 routes from ~3200 req/sec to ~4500 req/sec.
