### PR TITLE
Pre-calculate the HashCode for TypeRegistration instances

### DIFF
--- a/src/TinyIoC/TinyIoC.cs
+++ b/src/TinyIoC/TinyIoC.cs
@@ -2546,6 +2546,8 @@ namespace TinyIoC
         #region Type Registrations
         public sealed class TypeRegistration
         {
+            private int _hashCode;
+
             public Type Type { get; private set; }
             public string Name { get; private set; }
 
@@ -2558,6 +2560,8 @@ namespace TinyIoC
             {
                 Type = type;
                 Name = name;
+
+                _hashCode = String.Concat(Type.FullName, "|", Name).GetHashCode();
             }
 
             public override bool Equals(object obj)
@@ -2578,7 +2582,7 @@ namespace TinyIoC
 
             public override int GetHashCode()
             {
-                return String.Format("{0}|{1}", Type.FullName, Name).GetHashCode();
+                return _hashCode;
             }
         }
         private readonly SafeDictionary<TypeRegistration, ObjectFactoryBase> _RegisteredTypes;


### PR DESCRIPTION
Moved the hash code calculation into the TypeRegistration constructor (as previously suggested).
