### PR TITLE
TinyIOC shouldn't scan through IronPython and IronRuby assemblies when doing auto-register.

### DIFF
--- a/src/TinyIoC/TinyIoC.cs
+++ b/src/TinyIoC/TinyIoC.cs
@@ -2826,6 +2826,8 @@ namespace TinyIoC
                 asm => asm.FullName.StartsWith("mscorlib,", StringComparison.InvariantCulture),
                 asm => asm.FullName.StartsWith("CR_VSTest", StringComparison.InvariantCulture),
                 asm => asm.FullName.StartsWith("DevExpress.CodeRush", StringComparison.InvariantCulture),
+                asm => asm.FullName.StartsWith("IronPython", StringComparison.InvariantCulture),
+                asm => asm.FullName.StartsWith("IronRuby", StringComparison.InvariantCulture),
             };
 
             foreach (var check in ignoreChecks)


### PR DESCRIPTION
Title says all.
