### PR TITLE
Feature: Resolve factory delegates

### DIFF
--- a/src/TinyIoC.Tests/TinyIoC.Tests.csproj
+++ b/src/TinyIoC.Tests/TinyIoC.Tests.csproj
@@ -77,6 +77,7 @@
     <Compile Include="TestData\NestedInterfaceDependencies.cs" />
     <Compile Include="TestData\TinyMessengerTestData.cs" />
     <Compile Include="TestData\UtilityMethods.cs" />
+    <Compile Include="TinyIoCResolveFactoryDelegateTests.cs" />
     <Compile Include="TinyIoCFunctionalTests.cs" />
     <Compile Include="TinyIoCTests.cs" />
     <Compile Include="TinyMessageSubscriptionTokenTests.cs" />

--- a/src/TinyIoC.Tests/TinyIoCResolveFactoryDelegateTests.cs
+++ b/src/TinyIoC.Tests/TinyIoCResolveFactoryDelegateTests.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TinyIoC.Tests.TestData;
+
+namespace TinyIoC.Tests
+{
+    [TestClass]
+    public class TinyIoCResolveFactoryDelegateTests
+    {
+        class Example
+        {
+            public delegate Example Factory(int value);
+
+            public Example(int value, Dependency dependency)
+            {
+                Value = value;
+                Dependency = dependency;
+            }
+
+            public int Value { get; private set; }
+            public Dependency Dependency { get; private set; }
+        }
+
+        class Dependency
+        {
+        }
+
+        [TestMethod]
+        public void Resolve_FactoryDelegate_ReturnsDelegateThatCanConstructInstance()
+        {
+            var container = UtilityMethods.GetContainer();
+            
+            var factory = container.Resolve<Example.Factory>();
+            var createdObject = factory(1);
+
+            Assert.AreEqual(1, createdObject.Value);
+            Assert.IsNotNull(createdObject.Dependency);
+        }
+
+        [TestMethod]
+        public void Resolve_FactoryDelegate_CachesDelegate()
+        {
+            var container = UtilityMethods.GetContainer();
+
+            var factory1 = container.Resolve<Example.Factory>();
+            var factory2 = container.Resolve<Example.Factory>();
+
+            Assert.AreSame(factory1, factory2);
+        }
+    }
+}


### PR DESCRIPTION
Scenario: A class that only needs some constructor arguments resolved by the container and rest provided by the calling code. We can define a "factory" delegate that only has the non-container-resolved parameters.

``` csharp
public class Logger
{
    public delegate Logger Factory(int indent);

    public Logger(int indent, IOutput output)
    {
        ...
    }
}
```

Then we can resolve the factory delegate and use it to create instances.

```
var loggerFactory = container.Resolve<Logger.Factory>();
var logger = loggerFactory(4);
```

The created Logger instance will have `indent=4` and `output={whatever the container provided}`.
