### PR TITLE
AutoRegister can optionally register multiple implementations of an abstract

### DIFF
--- a/src/TinyIoC.Tests/TinyIoCTests.cs
+++ b/src/TinyIoC.Tests/TinyIoCTests.cs
@@ -1457,25 +1457,25 @@ namespace TinyIoC.Tests
 
         [TestMethod]
         [ExpectedException(typeof(TinyIoCAutoRegistrationException))]
-        public void AutoRegister_ThisAssemblySpecifiedIgnoreDuplicatesOff_ThrowsException()
+        public void AutoRegister_ThisAssemblySpecifiedDuplicateActionFail_ThrowsException()
         {
             var container = UtilityMethods.GetContainer();
-            container.AutoRegister(new[] { this.GetType().Assembly }, false);
+            container.AutoRegister(new[] { this.GetType().Assembly }, DuplicateImplementationActions.Fail);
             Assert.IsTrue(false);
         }
 
         [TestMethod]
-        public void AutoRegister_TinyIoCAssemblySpecifiedIgnoreDuplicatesOff_NoErrors()
+        public void AutoRegister_TinyIoCAssemblySpecifiedDuplicateActionFail_NoErrors()
         {
             var container = UtilityMethods.GetContainer();
-            container.AutoRegister(new[] { typeof(TinyIoCContainer).Assembly }, false);
+            container.AutoRegister(new[] { typeof(TinyIoCContainer).Assembly }, DuplicateImplementationActions.Fail);
         }
 
         [TestMethod]
-        public void AutoRegister_SpecifiedRegisterMultiple_RegistersMultipleImplementations()
+        public void AutoRegister_SpecifiedDuplicateActionRegisterMultiple_RegistersMultipleImplementations()
         {
             var container = UtilityMethods.GetContainer();
-            container.AutoRegister(new[] { this.GetType().Assembly }, true, true);
+            container.AutoRegister(new[] { this.GetType().Assembly }, DuplicateImplementationActions.RegisterMultiple);
             
             var results = container.ResolveAll<ITestInterface>();
 

--- a/src/TinyIoC/TinyIoC.cs
+++ b/src/TinyIoC/TinyIoC.cs
@@ -498,6 +498,13 @@ namespace TinyIoC
         Fail
     }
 
+    public enum DuplicateImplementationActions
+    {
+        RegisterSingle,
+        RegisterMultiple,
+        Fail
+    }
+
     /// <summary>
     /// Resolution settings
     /// </summary>
@@ -768,7 +775,7 @@ namespace TinyIoC
         public void AutoRegister()
         {
 #if APPDOMAIN_GETASSEMBLIES
-            AutoRegisterInternal(AppDomain.CurrentDomain.GetAssemblies().Where(a => !IsIgnoredAssembly(a)), true, false, null);
+            AutoRegisterInternal(AppDomain.CurrentDomain.GetAssemblies().Where(a => !IsIgnoredAssembly(a)), DuplicateImplementationActions.RegisterSingle, null);
 #else
             AutoRegisterInternal(new Assembly[] {this.GetType().Assembly}, true, null);
 #endif
@@ -785,7 +792,7 @@ namespace TinyIoC
         public void AutoRegister(Func<Type, bool> registrationPredicate)
         {
 #if APPDOMAIN_GETASSEMBLIES
-            AutoRegisterInternal(AppDomain.CurrentDomain.GetAssemblies().Where(a => !IsIgnoredAssembly(a)), true, false, registrationPredicate);
+            AutoRegisterInternal(AppDomain.CurrentDomain.GetAssemblies().Where(a => !IsIgnoredAssembly(a)), DuplicateImplementationActions.RegisterSingle, registrationPredicate);
 #else
             AutoRegisterInternal(new Assembly[] {this.GetType().Assembly}, true, registrationPredicate);
 #endif
@@ -794,27 +801,12 @@ namespace TinyIoC
         /// <summary>
         /// Attempt to automatically register all non-generic classes and interfaces in the current app domain.
         /// </summary>
-        /// <param name="ignoreDuplicateImplementations">Whether to ignore duplicate implementations of an interface/base class. False=throw an exception</param>
+        /// <param name="duplicateAction">What action to take when encountering duplicate implementations of an interface/base class.</param>
         /// <exception cref="TinyIoCAutoRegistrationException"/>
-        public void AutoRegister(bool ignoreDuplicateImplementations)
+        public void AutoRegister(DuplicateImplementationActions duplicateAction)
         {
 #if APPDOMAIN_GETASSEMBLIES
-            AutoRegisterInternal(AppDomain.CurrentDomain.GetAssemblies().Where(a => !IsIgnoredAssembly(a)), ignoreDuplicateImplementations, false, null);
-#else
-            AutoRegisterInternal(new Assembly[] { this.GetType().Assembly }, ignoreDuplicateImplementations, null);
-#endif
-        }
-
-        /// <summary>
-        /// Attempt to automatically register all non-generic classes and interfaces in the current app domain.
-        /// </summary>
-        /// <param name="ignoreDuplicateImplementations">Whether to ignore duplicate implementations of an interface/base class. False=throw an exception</param>
-        /// <param name="registerMultiple">If multiple implementations of an interface/base class exist, whether to register them all. False=only register the first one</param>
-        /// <exception cref="TinyIoCAutoRegistrationException"/>
-        public void AutoRegister(bool ignoreDuplicateImplementations, bool registerMultiple)
-        {
-#if APPDOMAIN_GETASSEMBLIES
-            AutoRegisterInternal(AppDomain.CurrentDomain.GetAssemblies().Where(a => !IsIgnoredAssembly(a)), ignoreDuplicateImplementations, registerMultiple, null);
+            AutoRegisterInternal(AppDomain.CurrentDomain.GetAssemblies().Where(a => !IsIgnoredAssembly(a)), duplicateAction, null);
 #else
             AutoRegisterInternal(new Assembly[] { this.GetType().Assembly }, ignoreDuplicateImplementations, null);
 #endif
@@ -824,13 +816,13 @@ namespace TinyIoC
         /// Attempt to automatically register all non-generic classes and interfaces in the current app domain.
         /// Types will only be registered if they pass the supplied registration predicate.
         /// </summary>
-        /// <param name="ignoreDuplicateImplementations">Whether to ignore duplicate implementations of an interface/base class. False=throw an exception</param>
+        /// <param name="duplicateAction">What action to take when encountering duplicate implementations of an interface/base class.</param>
         /// <param name="registrationPredicate">Predicate to determine if a particular type should be registered</param>
         /// <exception cref="TinyIoCAutoRegistrationException"/>
-        public void AutoRegister(bool ignoreDuplicateImplementations, Func<Type, bool> registrationPredicate)
+        public void AutoRegister(DuplicateImplementationActions duplicateAction, Func<Type, bool> registrationPredicate)
         {
 #if APPDOMAIN_GETASSEMBLIES
-            AutoRegisterInternal(AppDomain.CurrentDomain.GetAssemblies().Where(a => !IsIgnoredAssembly(a)), ignoreDuplicateImplementations, false, registrationPredicate);
+            AutoRegisterInternal(AppDomain.CurrentDomain.GetAssemblies().Where(a => !IsIgnoredAssembly(a)), duplicateAction, registrationPredicate);
 #else
             AutoRegisterInternal(new Assembly[] { this.GetType().Assembly }, ignoreDuplicateImplementations, registrationPredicate);
 #endif
@@ -845,7 +837,7 @@ namespace TinyIoC
         /// <param name="assemblies">Assemblies to process</param>
         public void AutoRegister(IEnumerable<Assembly> assemblies)
         {
-            AutoRegisterInternal(assemblies, true, false, null);
+            AutoRegisterInternal(assemblies, DuplicateImplementationActions.RegisterSingle, null);
         }
 
         /// <summary>
@@ -859,30 +851,18 @@ namespace TinyIoC
         /// <param name="registrationPredicate">Predicate to determine if a particular type should be registered</param>
         public void AutoRegister(IEnumerable<Assembly> assemblies, Func<Type, bool> registrationPredicate)
         {
-            AutoRegisterInternal(assemblies, true, false, registrationPredicate);
+            AutoRegisterInternal(assemblies, DuplicateImplementationActions.RegisterSingle, registrationPredicate);
         }
 
         /// <summary>
         /// Attempt to automatically register all non-generic classes and interfaces in the specified assemblies
         /// </summary>
         /// <param name="assemblies">Assemblies to process</param>
-        /// <param name="ignoreDuplicateImplementations">Whether to ignore duplicate implementations of an interface/base class. False=throw an exception</param>
+        /// <param name="duplicateAction">What action to take when encountering duplicate implementations of an interface/base class.</param>
         /// <exception cref="TinyIoCAutoRegistrationException"/>
-        public void AutoRegister(IEnumerable<Assembly> assemblies, bool ignoreDuplicateImplementations)
+        public void AutoRegister(IEnumerable<Assembly> assemblies, DuplicateImplementationActions duplicateAction)
         {
-            AutoRegisterInternal(assemblies, ignoreDuplicateImplementations, false, null);
-        }
-
-        /// <summary>
-        /// Attempt to automatically register all non-generic classes and interfaces in the specified assemblies
-        /// </summary>
-        /// <param name="assemblies">Assemblies to process</param>
-        /// <param name="ignoreDuplicateImplementations">Whether to ignore duplicate implementations of an interface/base class. False=throw an exception</param>
-        /// <param name="registerMultiple">If multiple implementations of an interface/base class exist, whether to register them all. False=only register the first</param>
-        /// <exception cref="TinyIoCAutoRegistrationException"/>
-        public void AutoRegister(IEnumerable<Assembly> assemblies, bool ignoreDuplicateImplementations, bool registerMultiple)
-        {
-            AutoRegisterInternal(assemblies, ignoreDuplicateImplementations, registerMultiple, null);
+            AutoRegisterInternal(assemblies, duplicateAction, null);
         }
 
         /// <summary>
@@ -890,12 +870,12 @@ namespace TinyIoC
         /// Types will only be registered if they pass the supplied registration predicate.
         /// </summary>
         /// <param name="assemblies">Assemblies to process</param>
-        /// <param name="ignoreDuplicateImplementations">Whether to ignore duplicate implementations of an interface/base class. False=throw an exception</param>
+        /// <param name="duplicateAction">What action to take when encountering duplicate implementations of an interface/base class.</param>
         /// <param name="registrationPredicate">Predicate to determine if a particular type should be registered</param>
         /// <exception cref="TinyIoCAutoRegistrationException"/>
-        public void AutoRegister(IEnumerable<Assembly> assemblies, bool ignoreDuplicateImplementations, Func<Type, bool> registrationPredicate)
+        public void AutoRegister(IEnumerable<Assembly> assemblies, DuplicateImplementationActions duplicateAction, Func<Type, bool> registrationPredicate)
         {
-            AutoRegisterInternal(assemblies, ignoreDuplicateImplementations, false, registrationPredicate);
+            AutoRegisterInternal(assemblies, duplicateAction, registrationPredicate);
         }
 
         /// <summary>
@@ -2790,7 +2770,7 @@ namespace TinyIoC
 
         #region Internal Methods
         private readonly object _AutoRegisterLock = new object();
-        private void AutoRegisterInternal(IEnumerable<Assembly> assemblies, bool ignoreDuplicateImplementations, bool registerMultiple, Func<Type, bool> registrationPredicate)
+        private void AutoRegisterInternal(IEnumerable<Assembly> assemblies, DuplicateImplementationActions duplicateAction, Func<Type, bool> registrationPredicate)
         {
             lock (_AutoRegisterLock)
             {
@@ -2824,10 +2804,10 @@ namespace TinyIoC
 
                     if (implementations.Count() > 1)
                     {
-                        if (!ignoreDuplicateImplementations)
+                        if (duplicateAction == DuplicateImplementationActions.Fail)
                             throw new TinyIoCAutoRegistrationException(type, implementations);
 
-                        if (registerMultiple)
+                        if (duplicateAction == DuplicateImplementationActions.RegisterMultiple)
                         {
                             RegisterMultiple(type, implementations);
                             return;
@@ -3436,4 +3416,5 @@ namespace TinyIoC
 
         #endregion
     }
+
 }


### PR DESCRIPTION
I've replaced ignoreDuplicates with an enum parameter:
- Register Single
- Register Multiple
- Fail

This allows you to call AutoRegister followed by ResolveAll to return a collection of interface implementations.

*\* Breaking change *\* (my last check-in had a constructor overload instead but this was a bit smelly...)
