### PR TITLE
Support for delegate factories with singleton, multi-instance and custom lifetimes 

### DIFF
--- a/src/TinyIoC.Tests/TestData/BasicClasses.cs
+++ b/src/TinyIoC.Tests/TestData/BasicClasses.cs
@@ -22,6 +22,27 @@ namespace TinyIoC.Tests.TestData
 {
     namespace BasicClasses
     {
+
+        internal class CyclicA
+        {
+            readonly CyclicB dependency;
+
+            public CyclicA(CyclicB dependency)
+            {
+                this.dependency = dependency;
+            }
+        }
+
+        internal class CyclicB
+        {
+            readonly CyclicA dependency;
+
+            public CyclicB(CyclicA dependency)
+            {
+                this.dependency = dependency;
+            }
+        }
+
         internal interface ITestInterface
         {
         }

--- a/src/TinyIoC.Tests/TinyIoCFunctionalTests.cs
+++ b/src/TinyIoC.Tests/TinyIoCFunctionalTests.cs
@@ -38,6 +38,31 @@ namespace TinyIoC.Tests
     [TestClass]
     public class TinyIoCFunctionalTests
     {
+
+        [TestMethod]
+        public void Container_Throws_Whith_Simple_Cyclic_Dependency()
+        {
+            var container = UtilityMethods.GetContainer();
+            container.Register<CyclicA>();
+            container.Register<CyclicB>();
+
+            AssertHelper.ThrowsException<TinyIoCResolutionException>(() => container.Resolve<CyclicA>());
+
+        }
+
+
+        [TestMethod]
+        public void Container_Throws_Whith_Simple_Factory_Cyclic_Dependency()
+        {
+            var container = UtilityMethods.GetContainer();
+            container.Register<CyclicA>((c, o) => new CyclicA(c.Resolve<CyclicB>()));
+            container.Register<CyclicB>((c, o) => new CyclicB(c.Resolve<CyclicA>()));
+
+            AssertHelper.ThrowsException<TinyIoCResolutionException>(() => container.Resolve<CyclicA>());
+
+        }
+
+
         [TestMethod]
         public void NestedInterfaceDependencies_CorrectlyRegistered_ResolvesRoot()
         {

--- a/src/TinyIoC.Tests/TinyIoCTests.cs
+++ b/src/TinyIoC.Tests/TinyIoCTests.cs
@@ -1031,25 +1031,28 @@ namespace TinyIoC.Tests
         }
 
         [TestMethod]
-        //[ExpectedException(typeof(TinyIoCRegistrationException))]
-        public void Register_FactoryToSingletonFluent_ThrowsException()
+        public void Register_FactoryToSingletonFluent_Registers()
         {
             var container = UtilityMethods.GetContainer();
-            AssertHelper.ThrowsException<TinyIoCRegistrationException>(() => container.Register<TestClassDefaultCtor>((c, p) => new TestClassDefaultCtor()).AsSingleton());
-
-            // Should have thrown by now
-            //Assert.IsTrue(false);
+            container.Register<TestClassDefaultCtor>((c, p) => new TestClassDefaultCtor()).AsSingleton();
+            //works
         }
 
         [TestMethod]
-        //[ExpectedException(typeof(TinyIoCRegistrationException))]
-        public void Register_FactoryToMultiInstanceFluent_ThrowsException()
+        public void Register_FactoryToMultiInstanceFluent_Registers()
         {
             var container = UtilityMethods.GetContainer();
-            AssertHelper.ThrowsException<TinyIoCRegistrationException>(() => container.Register<TestClassDefaultCtor>((c, p) => new TestClassDefaultCtor()).AsMultiInstance());
+            container.Register<TestClassDefaultCtor>((c, p) => new TestClassDefaultCtor()).AsMultiInstance();
 
-            // Should have thrown by now
-            //Assert.IsTrue(false);
+            //works
+        }
+
+        [TestMethod]
+        public void Register_FactoryToCustomLifetime_Registers()
+        {
+            var container = UtilityMethods.GetContainer();
+            container.Register<TestClassDefaultCtor>((c, p) => new TestClassDefaultCtor()).AsPerRequestSingleton();
+            //works
         }
 
         [TestMethod]

--- a/src/TinyIoC/TinyIoCAspNetExtensions.cs
+++ b/src/TinyIoC/TinyIoCAspNetExtensions.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Web;
 
 namespace TinyIoC
@@ -12,12 +9,13 @@ namespace TinyIoC
 
         public object GetObject()
         {
-            return HttpContext.Current.Items[_KeyName];
+            return HttpContext.Current == null ? null : HttpContext.Current.Items[_KeyName];
         }
 
         public void SetObject(object value)
         {
-            HttpContext.Current.Items[_KeyName] = value;
+            if (HttpContext.Current != null)
+                HttpContext.Current.Items[_KeyName] = value;
         }
 
         public void ReleaseObject()


### PR DESCRIPTION
Support for delegate factories with singleton, multi-instance and custom lifetimes 
also made http lifetime provider not bomb out in unit tests
