### PR TITLE
Fixed compile error for WP8

### DIFF
--- a/src/TinyIoC/TinyIoC.cs
+++ b/src/TinyIoC/TinyIoC.cs
@@ -3789,11 +3789,12 @@ namespace TinyIoC
                 if (registerType.IsInterface())
                 {
 #if WINDOWS_PHONE
-                    return registerImplementation.GetInterface(registerType.Name, true) != null;
+                    if (registerImplementation.GetInterface(registerType.Name, true) == null)
 #else
                     if (!registerImplementation.FindInterfaces((t, o) => t.Name == registerType.Name, null).Any())
-                        return false;
 #endif
+                        return false;
+
                 }
                 else if (registerType.IsAbstract() && registerImplementation.BaseType() != registerType)
                 {


### PR DESCRIPTION
FindInterfaces is not supported by WP8 so replaced it with GetInterface
check. There might be a better way to handle this but this was done as a quick fix to get TinyIoC working with WP8.
