### PR TITLE
ResolveAll returns the first class registered twice

### DIFF
--- a/src/TinyIoC.Tests/TinyIoCTests.cs
+++ b/src/TinyIoC.Tests/TinyIoCTests.cs
@@ -2329,6 +2329,24 @@ namespace TinyIoC.Tests
         }
 
         [TestMethod]
+        public void ResolveAll_MultipleTypesRegisteredAfterAutoRegister_ReturnsIEnumerableWithCorrectCount()
+        {
+            var container = UtilityMethods.GetContainer();
+            var assemblies = new List<Assembly> { this.GetType().Assembly() };
+
+            container.AutoRegister(assemblies);
+            container.RegisterMultiple<ITestInterface2>(new[]
+            {
+                typeof (TestClass2),
+                typeof (TestClassWithInterfaceDependency)
+            });
+
+            var results = container.ResolveAll<ITestInterface2>();
+
+            Assert.AreEqual(2, results.Count());
+        }
+
+        [TestMethod]
         public void ResolveAll_NamedAndUnnamedRegisteredAndPassedTrue_ReturnsIEnumerableWithNamedAndUnnamedRegistrations()
         {
             var container = UtilityMethods.GetContainer();


### PR DESCRIPTION
I reported this as an issue in [Nancy#1657](https://github.com/NancyFx/Nancy/issues/1657) but I think it's a bug in TinyIoC. The Nancy issue has a repro and I put together a failing test that I think is correct. I haven't tried to fix this though because I'm not familiar enough with TinyIoC to know if this is really a bug or intended functionality.
