### PR TITLE
Cache concrete types

### DIFF
--- a/src/TinyIoC/TinyIoC.cs
+++ b/src/TinyIoC/TinyIoC.cs
@@ -3163,9 +3163,9 @@ namespace TinyIoC
             {
                 var types = assemblies.SelectMany(a => a.SafeGetTypes()).Where(t => !IsIgnoredType(t, registrationPredicate)).ToList();
 
-                var concreteTypes = from type in types
-                                    where type.IsClass() && (type.IsAbstract() == false) && (type != this.GetType() && (type.DeclaringType != this.GetType()) && (!type.IsGenericTypeDefinition()))
-                                    select type;
+                var concreteTypes = types
+                    .Where(type => type.IsClass() && (type.IsAbstract() == false) && (type != this.GetType() && (type.DeclaringType != this.GetType()) && (!type.IsGenericTypeDefinition())))
+                    .ToList();
 
                 foreach (var type in concreteTypes)
                 {
@@ -3190,7 +3190,7 @@ namespace TinyIoC
                                           where localType.IsAssignableFrom(implementationType)
                                           select implementationType;
 
-                    if (implementations.Count() > 1)
+                    if (implementations.Skip(1).Any())
                     {
                         if (duplicateAction == DuplicateImplementationActions.Fail)
                             throw new TinyIoCAutoRegistrationException(type, implementations);


### PR DESCRIPTION
Previously when invoking AutoRegister twice with a couple of thousand
concrete types and less than a thousand abstract types the concrete type
checking lambda was being invoked over five million times, taking a good
8 seconds to run under a profiler (and over a second without profiling).

Now it's being invoked less than fifty thousand times, with an overall
speedup of AutoRegister during profiling of over five times.
