### PR TITLE
Compiler Error CS1032: Cannot define/undefine preprocessor symbols af…

### DIFF
--- a/src/TinyIoC/TinyIoC.cs
+++ b/src/TinyIoC/TinyIoC.cs
@@ -28,7 +28,6 @@
 // depending on platform features. If the platform has an appropriate
 // #DEFINE then these should be set automatically below.
 #define EXPRESSIONS
-using System.Runtime.Serialization;
 
 // Platform supports System.Linq.Expressions
 #define COMPILED_EXPRESSIONS                // Platform supports compiling expressions
@@ -76,6 +75,8 @@ using System.Runtime.Serialization;
 #endif
 
 #endregion
+
+using System.Runtime.Serialization;
 
 namespace TinyIoC
 {


### PR DESCRIPTION
When compilation is done it produces a error from Compiler Error CS1032: Cannot define/undefine preprocessor symbols.

#define directive should be first in the code.