### PR TITLE
implement UnregisterMultiple

### DIFF
--- a/src/TinyIoC.Tests/TinyIoCTests.cs
+++ b/src/TinyIoC.Tests/TinyIoCTests.cs
@@ -3481,6 +3481,78 @@ namespace TinyIoC.Tests
 
         #endregion
 
+        #region Unregister Multiple
+
+        [TestMethod]
+        public void UnregisterMultiple_T_ValidTypes_CorrectCountReturnedByResolveAll()
+        {
+            var container = UtilityMethods.GetContainer();
+            container.RegisterMultiple<ITestInterface>(new Type[] { typeof(TestClassDefaultCtor), typeof(DisposableTestClassWithInterface) });
+
+            container.UnregisterMultiple<ITestInterface>(new Type[] {typeof(TestClassDefaultCtor)});
+            var result = container.ResolveAll<ITestInterface>();
+
+            Assert.AreEqual(1, result.Count());
+        }
+        
+        [TestMethod]
+        public void UnregisterMultiple_ValidTypes_CorrectCountReturnedByResolveAll()
+        {
+            var container = UtilityMethods.GetContainer();
+            container.RegisterMultiple(typeof(ITestInterface), new Type[] { typeof(TestClassDefaultCtor), typeof(DisposableTestClassWithInterface) });
+
+            container.UnregisterMultiple(typeof(ITestInterface), new Type[] {typeof(TestClassDefaultCtor)});
+            var result = container.ResolveAll<ITestInterface>();
+
+            Assert.AreEqual(1, result.Count());
+        }
+
+        [TestMethod]
+        public void UnregisterMultiple_T_ValidTypes_InstancesOfCorrectTypesReturnedByResolveAll()
+        {
+            var container = UtilityMethods.GetContainer();
+            container.RegisterMultiple<ITestInterface>(new Type[] { typeof(TestClassDefaultCtor), typeof(DisposableTestClassWithInterface) });
+
+            container.UnregisterMultiple<ITestInterface>(new Type[] { typeof(TestClassDefaultCtor) });
+            var result = container.ResolveAll<ITestInterface>();
+
+            Assert.IsNotNull(result.Where(o => o.GetType() == typeof(DisposableTestClassWithInterface)).FirstOrDefault());
+        }
+
+        [TestMethod]
+        public void UnregisterMultiple_T_Null_Throws()
+        {
+            var container = UtilityMethods.GetContainer();
+
+            try
+            {
+                container.UnregisterMultiple<ITestInterface>(null);
+
+                Assert.Fail();
+            }
+            catch (ArgumentNullException)
+            {
+            }
+        }
+        
+        [TestMethod]
+        public void UnregisterMultiple_T_ATypeThatDoesntImplementTheRegisterType_Throws()
+        {
+            var container = UtilityMethods.GetContainer();
+
+            try
+            {
+                container.UnregisterMultiple<ITestInterface>(new Type[] { typeof(TestClassDefaultCtor), typeof(TestClass2) });
+
+                Assert.Fail();
+            }
+            catch (ArgumentException)
+            {
+            }
+        }
+
+        #endregion
+
         #endregion
     }
 }

--- a/src/TinyIoC/TinyIoC.cs
+++ b/src/TinyIoC/TinyIoC.cs
@@ -1650,6 +1650,30 @@ namespace TinyIoC
             return RemoveRegistration(typeRegistration);
         }
 
+        public void UnregisterMultiple(Type registrationType, IEnumerable<Type> implementationTypes)
+        {
+            if (implementationTypes == null)
+                throw new ArgumentNullException("implementationTypes", "types is null.");
+
+            foreach (var type in implementationTypes)
+//#if NETFX_CORE
+//              if (!registrationType.GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()))
+//#else
+                if (!registrationType.IsAssignableFrom(type))
+//#endif
+                    throw new ArgumentException(String.Format("types: The type {0} is not assignable from {1}", registrationType.FullName, type.FullName));
+
+            foreach (var type in implementationTypes)
+            {
+                Unregister(registrationType, type.FullName);
+            }
+        }
+        
+        public void UnregisterMultiple<UnregisterType>(IEnumerable<Type> implementationTypes)
+        {
+            UnregisterMultiple(typeof(UnregisterType), implementationTypes);
+        }
+
         #endregion
 
         #region Resolution


### PR DESCRIPTION
This is an implementation of `UnregisterMultiple`. The main reason this is needed is that `RegisterMultiple` uses a convention to register each type as a named type with the full name of the type. Therefore if you had previous registered a type using...
```
container.RegisterMultiple<TInterface>(new [] { type });
```
...you would then have to unregister the type using...
```
container.Unregister<TInterface>(type.FullName);
```
This is a little unintuitive. This PR allows you to unregister the type using...
```
container.UnregisterMultiple<TInterface>(new [] { type });
```
...which is the same syntax that the type was originally registered.