### PR TITLE
Fix duplicates returned by ResolveAll() when identical parent and child registration keys

### DIFF
--- a/src/TinyIoC.Tests/TinyIoCTests.cs
+++ b/src/TinyIoC.Tests/TinyIoCTests.cs
@@ -3001,6 +3001,39 @@ namespace TinyIoC.Tests
         }
 
         [TestMethod]
+        public void ResolveAll_ChildContainerRegistrationsOverrideParentContainerRegistrations_ReturnsChildRegistrationsWithoutDuplicates()
+        {
+            var parentContainer = UtilityMethods.GetContainer();
+            var childContainer = parentContainer.GetChildContainer();
+            parentContainer.Register<ITestInterface>(new TestClassDefaultCtor(), "1");
+            parentContainer.Register<ITestInterface>(new TestClassDefaultCtor(), "2");
+            parentContainer.Register<ITestInterface>(new TestClassDefaultCtor(), "3");
+            childContainer.Register<ITestInterface>(new TestClassDefaultCtor(), "1");
+            childContainer.Register<ITestInterface>(new TestClassDefaultCtor(), "2");
+            childContainer.Register<ITestInterface>(new TestClassDefaultCtor(), "3");
+
+            var result = childContainer.ResolveAll<ITestInterface>();
+
+            Assert.AreEqual(3, result.Count());
+        }
+
+        [TestMethod]
+        public void ResolveAll_ChildContainerRegistrationOverridesParentContainerRegistration_ReturnsChildRegistrations()
+        {
+            var parentContainer = UtilityMethods.GetContainer();
+            var childContainer = parentContainer.GetChildContainer();
+            var parentInstance = new TestClassDefaultCtor();
+            var childInstance = new TestClassDefaultCtor();
+            parentContainer.Register<ITestInterface>(parentInstance, "1");
+            childContainer.Register<ITestInterface>(childInstance, "1");
+
+            var result = childContainer.ResolveAll<ITestInterface>();
+
+            Assert.AreEqual(1, result.Count());
+            Assert.AreSame(childInstance, result.Single());
+        }
+
+        [TestMethod]
         public void ResolveAll_ParentContainerMultiInstanceRegistrationWithDependencyInChildContainer_ReturnsRegistrationWithChildContainerDependencyInstance()
         {
             var parentContainer = UtilityMethods.GetContainer();

--- a/src/TinyIoC/TinyIoC.cs
+++ b/src/TinyIoC/TinyIoC.cs
@@ -3972,7 +3972,7 @@ namespace TinyIoC
 
         private IEnumerable<object> ResolveAllInternal(Type resolveType, bool includeUnnamed)
         {
-            var registrations = _RegisteredTypes.Keys.Where(tr => tr.Type == resolveType).Concat(GetParentRegistrationsForType(resolveType));
+            var registrations = _RegisteredTypes.Keys.Where(tr => tr.Type == resolveType).Concat(GetParentRegistrationsForType(resolveType)).Distinct();
 
             if (!includeUnnamed)
                 registrations = registrations.Where(tr => tr.Name != string.Empty);


### PR DESCRIPTION
Fixes #87 .  Fixes duplicate child instances returned by ResolveAll() when registrations of the identical type and name exist on parent and child containers.

TinyIoC currently returns duplicates of the registration on the child container.  This PR preserves the principle that identical type-and-name registrations on the child container should supersede-and-hide those on the parent container, but prevents duplicates being returned.

Tests added to demonstrate behaviour.  No existing ResolveAll<>() tests break.