### PR TITLE
Fix compilation with PORTABLE symbol.

### DIFF
--- a/src/TinyIoC/TinyIoC.cs
+++ b/src/TinyIoC/TinyIoC.cs
@@ -361,7 +361,7 @@ namespace TinyIoC
 
 #if PORTABLE || NETSTANDARD1_0 || NETSTANDARD1_1 || NETSTANDARD1_2
     [Flags]
-    internal enum BindingFlags {
+    public enum BindingFlags {
         Default = 0,
         IgnoreCase = 1,
         DeclaredOnly = 2,
@@ -4246,7 +4246,7 @@ namespace TinyIoC
     }
 #endif
     // reverse shim for WinRT SR changes...
-#if (!NETFX_CORE && !PORTABLE && !NETSTANDARD1_0 && !NETSTANDARD1_1 && !NETSTANDARD1_2 && !NETSTANDARD1_3 && !NETSTANDARD1_4 && !NETSTANDARD1_5 || !NETSTANDARD1_6)
+#if (!NETFX_CORE && !PORTABLE && !NETSTANDARD1_0 && !NETSTANDARD1_1 && !NETSTANDARD1_2 && !NETSTANDARD1_3 && !NETSTANDARD1_4 && !NETSTANDARD1_5 && !NETSTANDARD1_6)
     static class ReverseTypeExtender
     {
         public static bool IsClass(this Type type)


### PR DESCRIPTION
Compiling with the PORTABLE symbol results in several errors.

> The namespace 'TinyIoC' already contains a definition for
> 'ReverseTypeExtender'

The NETSTANDARD1_6 symbol is OR'd instead of AND'd. Since the rest of
the symbols are AND'd, this appears to be a copy-and-paste error.

> Inconsistent accessibility: parameter type 'BindingFlags' is less
> accessible than method 'TypeExtensions.GetConstructors(Type,
> BindingFlags)'

The BindingFlags enum is marked internal; however, it is included in
various public method signatures.
