### PR TITLE
BUG: Child container unable to resolve open generic.

### DIFF
--- a/src/TinyIoC.Tests/TinyIoCTests.cs
+++ b/src/TinyIoC.Tests/TinyIoCTests.cs
@@ -3298,6 +3298,22 @@ namespace TinyIoC.Tests
         }
 #endif
 
+
+#if RESOLVE_OPEN_GENERICS
+        [TestMethod]
+        public void Resolve_RegisteredOpenGenericInParent_CanBeResolvedByChild()
+        {
+            var container = UtilityMethods.GetContainer();
+            container.Register(typeof(IThing<>), typeof(DefaultThing<>));
+
+            var child = container.GetChildContainer();
+
+            var result = child.Resolve<IThing<object>>();
+             
+            Assert.IsInstanceOfType(result, typeof(DefaultThing<object>));
+        }
+#endif
+
         #region Unregister
 
         private readonly ResolveOptions options = ResolveOptions.FailUnregisteredAndNameNotFound;

--- a/src/TinyIoC/TinyIoC.cs
+++ b/src/TinyIoC/TinyIoC.cs
@@ -3712,6 +3712,20 @@ namespace TinyIoC
                 return null;
 
             ObjectFactoryBase factory;
+
+            if (registration.Type.IsGenericType())
+            {
+                var openTypeRegistration = new TypeRegistration(registration.Type.GetGenericTypeDefinition(),
+                                                                registration.Name);
+
+                if (_Parent._RegisteredTypes.TryGetValue(openTypeRegistration, out factory))
+                {
+                    return factory.GetFactoryForChildContainer(openTypeRegistration.Type, _Parent, this);
+                }
+
+                return _Parent.GetParentObjectFactory(registration);
+            }
+
             if (_Parent._RegisteredTypes.TryGetValue(registration, out factory))
             {
                 return factory.GetFactoryForChildContainer(registration.Type, _Parent, this);


### PR DESCRIPTION
BUG: A child container was unable to resolve an open generic registered with its parent container.