### PR TITLE
Added TinyIoCConstructorAttribute with tests

### DIFF
--- a/src/TinyIoC.Tests/TestData/BasicClasses.cs
+++ b/src/TinyIoC.Tests/TestData/BasicClasses.cs
@@ -381,5 +381,59 @@ namespace TinyIoC.Tests.TestData
                 return new T();
             }
         }
+
+        internal class TestClassWithConstructorAttrib
+        {
+            [TinyIoCConstructor]
+            public TestClassWithConstructorAttrib()
+            {
+                AttributeConstructorUsed = true;
+            }
+
+            public TestClassWithConstructorAttrib(object someParameter)
+            {
+                AttributeConstructorUsed = false;
+            }
+
+            public bool AttributeConstructorUsed { get; private set; }
+        }
+
+        internal class TestClassWithInternalConstructorAttrib
+        {
+            [TinyIoCConstructor]
+            internal TestClassWithInternalConstructorAttrib()
+            {
+                AttributeConstructorUsed = true;
+            }
+
+            public TestClassWithInternalConstructorAttrib(object someParameter)
+            {
+                AttributeConstructorUsed = false;
+            }
+
+            public bool AttributeConstructorUsed { get; private set; }
+        }
+
+        internal class TestClassWithManyConstructorAttribs
+        {
+            [TinyIoCConstructor]
+            public TestClassWithManyConstructorAttribs()
+            {
+                MostGreedyAttribCtorUsed = false;
+            }
+
+            [TinyIoCConstructor]
+            public TestClassWithManyConstructorAttribs(object someParameter)
+            {
+                MostGreedyAttribCtorUsed = true;
+            }
+
+            public TestClassWithManyConstructorAttribs(object a, object b)
+            {
+                MostGreedyAttribCtorUsed = false;
+            }
+
+            public bool MostGreedyAttribCtorUsed { get; private set; }
+        }
     }
 }

--- a/src/TinyIoC.Tests/TinyIoCTests.cs
+++ b/src/TinyIoC.Tests/TinyIoCTests.cs
@@ -1626,6 +1626,45 @@ namespace TinyIoC.Tests
         }
 
         [TestMethod]
+        public void Resolve_ConstructorSpecifiedWithAttribute_UsesCorrectCtor()
+        {
+            var container = UtilityMethods.GetContainer();
+            var result = container.Resolve<TestClassWithConstructorAttrib>();
+
+            Assert.IsTrue(result.AttributeConstructorUsed);
+        }
+
+        [TestMethod]
+        public void Resolve_InternalConstructorSpecifiedWithAttribute_UsesCorrectCtor()
+        {
+            var container = UtilityMethods.GetContainer();
+            var result = container.Resolve<TestClassWithInternalConstructorAttrib>();
+
+            Assert.IsTrue(result.AttributeConstructorUsed);
+        }
+
+        [TestMethod]
+        public void Resolve_ManyConstructorsSpecifiedWithAttribute_UsesCorrectCtor()
+        {
+            var container = UtilityMethods.GetContainer();
+            var result = container.Resolve<TestClassWithManyConstructorAttribs>();
+
+            Assert.IsTrue(result.MostGreedyAttribCtorUsed);
+        }
+
+        [TestMethod]
+        public void Resolve_AttributeConstructorOverriden_UsesCorrectCtor()
+        {
+            var container = UtilityMethods.GetContainer();
+            container.Register<TestClassWithConstructorAttrib>()
+                .UsingConstructor(() => new TestClassWithConstructorAttrib(null)); // The non-attribute constructor
+
+            var result = container.Resolve<TestClassWithConstructorAttrib>();
+
+            Assert.IsFalse(result.AttributeConstructorUsed);
+        }
+
+        [TestMethod]
         public void CanResolve_ConstructorSpecifiedThatRequiresParametersButNonePassed_ReturnsFalse()
         {
             var container = UtilityMethods.GetContainer();


### PR DESCRIPTION
I found that I was writing some pretty ugly `UsingConstructor()` lambdas and decided there could be a better alternative. Added the option of specifying which constructor(s) to use with an attribute.

Also added the option of using internal constructors.