### PR TITLE
Fix TinyIoC for use in dotnetstandard builds

### DIFF
--- a/src/TinyIoC/TinyIoC.cs
+++ b/src/TinyIoC/TinyIoC.cs
@@ -361,7 +361,7 @@ namespace TinyIoC
 
 #if PORTABLE || NETSTANDARD1_0 || NETSTANDARD1_1 || NETSTANDARD1_2
     [Flags]
-    internal enum BindingFlags {
+    public enum BindingFlags {
         Default = 0,
         IgnoreCase = 1,
         DeclaredOnly = 2,
@@ -4246,7 +4246,7 @@ namespace TinyIoC
     }
 #endif
     // reverse shim for WinRT SR changes...
-#if (!NETFX_CORE && !PORTABLE && !NETSTANDARD1_0 && !NETSTANDARD1_1 && !NETSTANDARD1_2 && !NETSTANDARD1_3 && !NETSTANDARD1_4 && !NETSTANDARD1_5 || !NETSTANDARD1_6)
+#if (!NETFX_CORE && !PORTABLE && !NETSTANDARD1_0 && !NETSTANDARD1_1 && !NETSTANDARD1_2 && !NETSTANDARD1_3 && !NETSTANDARD1_4 && !NETSTANDARD1_5 && !NETSTANDARD1_6)
     static class ReverseTypeExtender
     {
         public static bool IsClass(this Type type)


### PR DESCRIPTION
I think this duplicates a small bit of the work done by #106 but this was the most minimal change set I could make for a build complete for me when adding TinyIoC.cs to a new .NET Standard 1.0 project. 

I may be off base, but I thought this might save someone 5 minutes. 