### PR TITLE
Fix Resolve for Types with Generic Interfaces

### DIFF
--- a/src/TinyIoC.Tests/TestData/BasicClasses.cs
+++ b/src/TinyIoC.Tests/TestData/BasicClasses.cs
@@ -26,6 +26,10 @@ namespace TinyIoC.Tests.TestData
         {
         }
 
+        internal interface ITestInterface<I, S>
+        {
+        }
+
         internal class TestClassDefaultCtor : ITestInterface
         {
             public string Prop1 { get; set; }
@@ -193,6 +197,21 @@ namespace TinyIoC.Tests.TestData
             }
         }
 
+        internal class GenericClassWithGenericInterface<I, S> : ITestInterface<I, S>
+        {
+            public I Prop1 { get; set; }
+            public S Prop2 { get; set; }
+
+             public GenericClassWithGenericInterface()
+             {
+             }
+
+             public GenericClassWithGenericInterface(I prop1, S prop2)
+            {
+                Prop1 = prop1;
+                Prop2 = prop2;
+            }
+        }
 
         internal class GenericClassWithParametersAndDependencies<I, S>
         {

--- a/src/TinyIoC.Tests/TinyIoCTests.cs
+++ b/src/TinyIoC.Tests/TinyIoCTests.cs
@@ -552,6 +552,30 @@ namespace TinyIoC.Tests
         }
 
         [TestMethod]
+        public void Resolve_RegisteredGenericTypeWithGenericInterfaceCorrectGenericTypes_Resolves()
+        {
+            var container = UtilityMethods.GetContainer();
+            container.Register<ITestInterface<int, string>, GenericClassWithGenericInterface<int, string>>();
+
+            var result = container.Resolve<ITestInterface<int, string>>();
+
+            Assert.IsInstanceOfType(result, typeof(GenericClassWithGenericInterface<int, string>));
+        }
+
+        [TestMethod]
+        public void Resolve_RegisteredGenericTypeWithGenericInterfaceCorrectGenericTypesWithParent_Resolves()
+        {
+            var container = UtilityMethods.GetContainer();
+            var child = container.GetChildContainer();
+            container.Register<ITestInterface<int, string>>(new GenericClassWithGenericInterface<int, string>());
+
+            var result = child.Resolve<ITestInterface<int, string>>();
+
+            Assert.IsInstanceOfType(result, typeof(GenericClassWithGenericInterface<int, string>));
+        }
+
+
+        [TestMethod]
         public void Register_NamedRegistration_CanRegister()
         {
             var container = UtilityMethods.GetContainer();

--- a/src/TinyIoC/TinyIoC.cs
+++ b/src/TinyIoC/TinyIoC.cs
@@ -3718,7 +3718,7 @@ namespace TinyIoC
 
             if (registration.Type.IsGenericType())
             {
-                var openTypeRegistration = new TypeRegistration(registration.Type.GetGenericTypeDefinition(),
+                var openTypeRegistration = new TypeRegistration(registration.Type,
                                                                 registration.Name);
 
                 if (_Parent._RegisteredTypes.TryGetValue(openTypeRegistration, out factory))


### PR DESCRIPTION
Resolving types with generic interfaces failed. The given generic type was converted into it's generic definition before it was passed to the parent container. #126