### PR TITLE
Provide requested type as factory param

### DIFF
--- a/src/TinyIoC/TinyIoC.cs
+++ b/src/TinyIoC/TinyIoC.cs
@@ -2903,6 +2903,12 @@ namespace TinyIoC
 
             public override object GetObject(Type requestedType, TinyIoCContainer container, NamedParameterOverloads parameters, ResolveOptions options)
             {
+#if RESOLVE_OPEN_GENERICS
+                // Make the requested type available to the factory function
+                parameters = new NamedParameterOverloads(parameters);
+                parameters["__requestedType"] = requestedType;
+#endif
+
                 try
                 {
                     return _factory.Invoke(container, parameters);

--- a/tests/TinyIoC.Tests/TinyIoCTests.cs
+++ b/tests/TinyIoC.Tests/TinyIoCTests.cs
@@ -3422,6 +3422,35 @@ namespace TinyIoC.Tests
         }
 #endif
 
+#if RESOLVE_OPEN_GENERICS
+        [TestMethod]
+        public void Resolve_RegisteredOpenGeneric_CanGetGenericParamAsRequestedType()
+        {
+            // container.Register(
+            //     typeof(ILogger<>),
+            //     (c, p) =>
+            //     {
+            //         var type = (p["__requestedType"] as Type)?.GenericTypeArguments[0];
+            //         Debug.Assert(type != null, nameof(type) + " != null");
+            //         return c.Resolve<ILoggerFactory>().CreateLogger(type);
+            //     });
+
+            var container = UtilityMethods.GetContainer();
+            container.Register(typeof(IThing<>), (c, parameters) =>
+            {
+                Assert.IsNotNull(parameters["__requestedType"]);
+                var genericTypeArguments = (parameters["__requestedType"] as Type).GenericTypeArguments;
+                Assert.IsTrue(genericTypeArguments.Length > 0);
+                var returnType = typeof(DefaultThing<>).MakeGenericType(genericTypeArguments);
+                return Activator.CreateInstance(returnType);
+            });
+
+            var result = container.Resolve<IThing<object>>();
+
+            Assert.IsInstanceOfType(result, typeof(DefaultThing<object>));
+        }
+#endif
+
         #region Unregister
 
         private readonly ResolveOptions options = ResolveOptions.FailUnregisteredAndNameNotFound;


### PR DESCRIPTION
For `RESOLVE_OPEN_GENERICS` add a new "__requestedType" parameter when calling a factory method providing the type object for the type being resolved. This allows factory methods for registered open generic types to properly resolve the particular closed generic type requested.