### PR TITLE
Fix child resolve for types with generic interfaces

### DIFF
--- a/src/TinyIoC/TinyIoC.cs
+++ b/src/TinyIoC/TinyIoC.cs
@@ -3716,23 +3716,26 @@ namespace TinyIoC
 
             ObjectFactoryBase factory;
 
-            if (registration.Type.IsGenericType())
-            {
-                var openTypeRegistration = new TypeRegistration(registration.Type,
-                                                                registration.Name);
-
-                if (_Parent._RegisteredTypes.TryGetValue(openTypeRegistration, out factory))
-                {
-                    return factory.GetFactoryForChildContainer(openTypeRegistration.Type, _Parent, this);
-                }
-
-                return _Parent.GetParentObjectFactory(registration);
-            }
-
             if (_Parent._RegisteredTypes.TryGetValue(registration, out factory))
             {
                 return factory.GetFactoryForChildContainer(registration.Type, _Parent, this);
             }
+
+#if RESOLVE_OPEN_GENERICS
+            // Attempt container resolution of open generic
+            if (registration.Type.IsGenericType())
+            {
+                var openTypeRegistration = new TypeRegistration(registration.Type.GetGenericTypeDefinition(),
+                                                                registration.Name);
+
+                if (_Parent._RegisteredTypes.TryGetValue(openTypeRegistration, out factory))
+                {
+                    return factory.GetFactoryForChildContainer(registration.Type, _Parent, this);
+                }
+
+                return _Parent.GetParentObjectFactory(registration);
+            }
+#endif
 
             return _Parent.GetParentObjectFactory(registration);
         }

--- a/tests/TinyIoC.Tests/TinyIoCTests.cs
+++ b/tests/TinyIoC.Tests/TinyIoCTests.cs
@@ -13,6 +13,12 @@
 // FITNESS FOR A PARTICULAR PURPOSE.
 //===============================================================================
 
+#region Preprocessor Directives
+
+#define RESOLVE_OPEN_GENERICS               // Platform supports resolving open generics
+
+#endregion
+
 using System;
 using System.Collections.Generic;
 using System.Linq;


### PR DESCRIPTION
Similar to #127 , when attempting to resolve an open generic type from a child container it would fail to lookup for the generic definition in the parent container.

There was already a test covering just this case in
https://github.com/grumpydev/TinyIoC/blob/master/tests/TinyIoC.Tests/TinyIoCTests.cs#L3367
but because it was within a RESOLVE_OPEN_GENERICS region with that directive never being set it was failing.

Not sure how your testing matrix is setup but now that I've added the directive to the file header it runs those tests properly.

This also resolves #128 