### PR TITLE
Fix Double Publish with PublishAsync

### DIFF
--- a/src/TinyMessenger/TinyMessenger.cs
+++ b/src/TinyMessenger/TinyMessenger.cs
@@ -802,10 +802,8 @@ namespace TinyMessenger
         #else
         private async void PublishAsyncInternal<TMessage>(TMessage message, AsyncCallback callback) where TMessage : class, ITinyMessage
         {
-            await Task
-                .Run(() => PublishInternal<TMessage>(message))
-                .ContinueWith(t => callback?.Invoke(t))
-                .ConfigureAwait(false);
+            PublishInternal<TMessage>(message);
+            callback?.Invoke(Task.CompletedTask);
         }
         #endif
 

--- a/src/TinyMessenger/TinyMessenger.cs
+++ b/src/TinyMessenger/TinyMessenger.cs
@@ -802,10 +802,10 @@ namespace TinyMessenger
         #else
         private async void PublishAsyncInternal<TMessage>(TMessage message, AsyncCallback callback) where TMessage : class, ITinyMessage
         {
-            Action publishAction = () => { PublishInternal<TMessage>(message); };
-
-            await Task.Run(publishAction.Invoke);
-            PublishInternal<TMessage>(message);
+            await Task
+                .Run(() => PublishInternal<TMessage>(message))
+                .ContinueWith(t => callback(t))
+                .ConfigureAwait(false);
         }
         #endif
 

--- a/src/TinyMessenger/TinyMessenger.cs
+++ b/src/TinyMessenger/TinyMessenger.cs
@@ -804,7 +804,7 @@ namespace TinyMessenger
         {
             await Task
                 .Run(() => PublishInternal<TMessage>(message))
-                .ContinueWith(t => callback(t))
+                .ContinueWith(t => callback?.Invoke(t))
                 .ConfigureAwait(false);
         }
         #endif

--- a/src/TinyMessenger/TinyMessenger.cs
+++ b/src/TinyMessenger/TinyMessenger.cs
@@ -800,10 +800,10 @@ namespace TinyMessenger
             publishAction.BeginInvoke(callback, null);
         }
         #else
-        private async void PublishAsyncInternal<TMessage>(TMessage message, AsyncCallback callback) where TMessage : class, ITinyMessage
+        private void PublishAsyncInternal<TMessage>(TMessage message, AsyncCallback callback) where TMessage : class, ITinyMessage
         {
-            PublishInternal<TMessage>(message);
-            callback?.Invoke(Task.CompletedTask);
+            Task.Run(() => PublishInternal<TMessage>(message))
+                .ContinueWith(t => callback?.Invoke(t));
         }
         #endif
 


### PR DESCRIPTION
Messages are published twice but the callback is never invoked when using `PublishAsync`.
Fixes #148