### PR TITLE
Ensure Source Embedding for PackageReference NuGet

### DIFF
--- a/src/TinyIoC.AspNetExtensions/TinyIoC.AspNetExtensions.csproj
+++ b/src/TinyIoC.AspNetExtensions/TinyIoC.AspNetExtensions.csproj
@@ -39,9 +39,15 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Source'">
-    <Content Include="TinyIoCAspNetExtensions.cs">
+    <Compile Include="TinyIoCAspNetExtensions.cs">
       <Pack>true</Pack>
       <PackageCopyToOutput>true</PackageCopyToOutput>
-    </Content>
+      <PackagePath>contentFiles/cs/any</PackagePath>
+    </Compile>
+    <Compile Include="TinyIoCAspNetExtensions.cs">
+      <Pack>true</Pack>
+      <PackageCopyToOutput>true</PackageCopyToOutput>
+      <PackagePath>content</PackagePath>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/src/TinyIoC/TinyIoC.csproj
+++ b/src/TinyIoC/TinyIoC.csproj
@@ -92,9 +92,15 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Source'">
-    <Content Include="TinyIoc.cs">
+    <Compile Include="TinyIoc.cs">
       <Pack>true</Pack>
       <PackageCopyToOutput>true</PackageCopyToOutput>
-    </Content>
+      <PackagePath>contentFiles/cs/any</PackagePath>
+    </Compile>
+    <Compile Include="TinyIoc.cs">
+      <Pack>true</Pack>
+      <PackageCopyToOutput>true</PackageCopyToOutput>
+      <PackagePath>content</PackagePath>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/src/TinyMessenger/TinyMessenger.csproj
+++ b/src/TinyMessenger/TinyMessenger.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'" Label="Build">
     <DefineConstants>$(DefineConstants);NETSTANDARD;NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
@@ -32,9 +32,15 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Source'">
-    <Content Include="TinyMessenger.cs">
+    <Compile Include="TinyMessenger.cs">
       <Pack>true</Pack>
       <PackageCopyToOutput>true</PackageCopyToOutput>
-    </Content>
+      <PackagePath>contentFiles/cs/any</PackagePath>
+    </Compile>
+    <Compile Include="TinyMessenger.cs">
+      <Pack>true</Pack>
+      <PackageCopyToOutput>true</PackageCopyToOutput>
+      <PackagePath>content</PackagePath>
+    </Compile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Modified the three .csproj files to support source embedding for `ProjectReference` NuGet references. I did some local tests by adding the created nupkg's to a test project (used latest Rider and VisualStudio 2017). The three files where added in both cases as links to the test project. I've not tested the old `packages.config` way for adding NuGets but as recommended in the [.nuspec reference](https://docs.microsoft.com/en-us/nuget/reference/nuspec#including-content-files) I included the old `content` folder for max compatibility.

Not sure if this fixes all installation issues, but should be a good starting point for #136.

