### PR TITLE
Fix Resolve Issue with Multiple AutoRegister Calls

### DIFF
--- a/src/TinyIoC/TinyIoC.cs
+++ b/src/TinyIoC/TinyIoC.cs
@@ -3582,7 +3582,7 @@ namespace TinyIoC
     }
     
     // TODO - find a better way to remove "system" assemblies from the auto registration
-        private readonly List<Func<Assembly, bool>> ignoredAssemlies = new List<Func<Assembly, bool>>()
+        private static readonly IReadOnlyList<Func<Assembly, bool>> ignoredAssemlies = new List<Func<Assembly, bool>>()
         {
             asm => asm.FullName.StartsWith("Microsoft.", StringComparison.Ordinal),
             asm => asm.FullName.StartsWith("System.", StringComparison.Ordinal),
@@ -3604,9 +3604,9 @@ namespace TinyIoC
 
             return false;
         }
-        
+
         // TODO - find a better way to remove "system" types from the auto registration
-        private readonly List<Func<Type, bool>> ignoreChecks = new List<Func<Type, bool>>()
+        private static readonly IReadOnlyList<Func<Type, bool>> ignoreChecks = new List<Func<Type, bool>>()
         {
             t => t.FullName.StartsWith("System.", StringComparison.Ordinal),
             t => t.FullName.StartsWith("Microsoft.", StringComparison.Ordinal),
@@ -3619,19 +3619,10 @@ namespace TinyIoC
 
         private bool IsIgnoredType(Type type, Func<Type, bool> registrationPredicate)
         {
-            if (registrationPredicate != null && !registrationPredicate(type))
-            {
-                ignoreChecks.Add(t => !registrationPredicate(t));
+            if (ignoreChecks.Any(c => c(type)))
                 return true;
-            }
 
-            for (int i = 0; i < ignoreChecks.Count; i++)
-            {
-                if (ignoreChecks[i](type))
-                    return true;
-            }
-
-            return false;
+            return registrationPredicate != null && !registrationPredicate(type);
         }
 
         private void RegisterDefaultTypes()

--- a/tests/TinyIoC.Tests/TinyIoCTests.cs
+++ b/tests/TinyIoC.Tests/TinyIoCTests.cs
@@ -3393,6 +3393,20 @@ namespace TinyIoC.Tests
             //Assert.IsInstanceOfType(result, typeof(TinyIoCResolutionException));
         }
 
+        [TestMethod]
+        public void AutoRegister_Resolve_MultipleCalls()
+        {
+            var container = UtilityMethods.GetContainer();
+
+            container.AutoRegister(new[] { this.GetType().Assembly }, t => typeof(ITestInterface).IsAssignableFrom(t));
+            Assert.IsNotNull(container.Resolve<ITestInterface>());
+            AssertHelper.ThrowsException<TinyIoCResolutionException>(() => container.Resolve<ITestInterface2>());
+
+            container.AutoRegister(new[] { this.GetType().Assembly }, t => typeof(ITestInterface2).IsAssignableFrom(t));
+            Assert.IsNotNull(container.Resolve<ITestInterface>());
+            Assert.IsNotNull(container.Resolve<ITestInterface2>());
+        }
+
 #if RESOLVE_OPEN_GENERICS
         [TestMethod]
         public void Register_OpenGeneric_DoesNotThrow()


### PR DESCRIPTION
The static list of ignore-types must not be changed to prevent side effects when resolving types with predicates.
Fixes #154