### PR TITLE
Fixes performance problem cause by deep hierarchies, ResolveAll, and unusable constructors  

### DIFF
--- a/src/TinyIoC/TinyIoC.cs
+++ b/src/TinyIoC/TinyIoC.cs
@@ -344,6 +344,43 @@ namespace TinyIoC
 #endif
     #endregion
 
+    #region ResolutionCache
+
+    enum ResolutionStatus
+    {
+        Resolvable,
+        Unresolvable,
+        Unknown
+    }
+
+    sealed class ResolutionCache
+    {
+        private SafeDictionary<Type, ConstructorInfo> _bestConstructorCache = new SafeDictionary<Type, ConstructorInfo>();
+        private SafeDictionary<ConstructorInfo, bool> _canConstructCache = new SafeDictionary<ConstructorInfo, bool>();
+
+        public bool TryGetBestConstructor(Type type, out ConstructorInfo bestConstructor)
+        {
+            return _bestConstructorCache.TryGetValue(type, out bestConstructor);
+        }
+
+        public void SetBestConstructor(Type type, ConstructorInfo ctor)
+        {
+            _bestConstructorCache[type] = ctor;
+        }
+
+        public bool TryGetCanConstruct(ConstructorInfo ctor, out bool canConstruct)
+        {
+            return _canConstructCache.TryGetValue(ctor, out canConstruct);
+        }
+
+        public void SetCanConstruct(ConstructorInfo ctor, bool canConstruct)
+        {
+            _canConstructCache[ctor] = canConstruct;
+        }
+    }
+
+    #endregion
+
     #region Extensions
 #if TINYIOC_INTERNAL
     internal
@@ -1851,7 +1888,7 @@ namespace TinyIoC
         /// <exception cref="TinyIoCResolutionException">Unable to resolve the type.</exception>
         public object Resolve(Type resolveType)
         {
-            return ResolveInternal(new TypeRegistration(resolveType), NamedParameterOverloads.Default, ResolveOptions.Default);
+            return ResolveInternal(new TypeRegistration(resolveType), NamedParameterOverloads.Default, ResolveOptions.Default, new ResolutionCache());
         }
 
         /// <summary>
@@ -1863,7 +1900,7 @@ namespace TinyIoC
         /// <exception cref="TinyIoCResolutionException">Unable to resolve the type.</exception>
         public object Resolve(Type resolveType, ResolveOptions options)
         {
-            return ResolveInternal(new TypeRegistration(resolveType), NamedParameterOverloads.Default, options);
+            return ResolveInternal(new TypeRegistration(resolveType), NamedParameterOverloads.Default, options, new ResolutionCache());
         }
 
         /// <summary>
@@ -1878,7 +1915,7 @@ namespace TinyIoC
         /// <exception cref="TinyIoCResolutionException">Unable to resolve the type.</exception>
         public object Resolve(Type resolveType, string name)
         {
-            return ResolveInternal(new TypeRegistration(resolveType, name), NamedParameterOverloads.Default, ResolveOptions.Default);
+            return ResolveInternal(new TypeRegistration(resolveType, name), NamedParameterOverloads.Default, ResolveOptions.Default, new ResolutionCache());
         }
 
         /// <summary>
@@ -1894,7 +1931,7 @@ namespace TinyIoC
         /// <exception cref="TinyIoCResolutionException">Unable to resolve the type.</exception>
         public object Resolve(Type resolveType, string name, ResolveOptions options)
         {
-            return ResolveInternal(new TypeRegistration(resolveType, name), NamedParameterOverloads.Default, options);
+            return ResolveInternal(new TypeRegistration(resolveType, name), NamedParameterOverloads.Default, options, new ResolutionCache());
         }
 
         /// <summary>
@@ -1909,7 +1946,7 @@ namespace TinyIoC
         /// <exception cref="TinyIoCResolutionException">Unable to resolve the type.</exception>
         public object Resolve(Type resolveType, NamedParameterOverloads parameters)
         {
-            return ResolveInternal(new TypeRegistration(resolveType), parameters, ResolveOptions.Default);
+            return ResolveInternal(new TypeRegistration(resolveType), parameters, ResolveOptions.Default, new ResolutionCache());
         }
 
         /// <summary>
@@ -1925,7 +1962,7 @@ namespace TinyIoC
         /// <exception cref="TinyIoCResolutionException">Unable to resolve the type.</exception>
         public object Resolve(Type resolveType, NamedParameterOverloads parameters, ResolveOptions options)
         {
-            return ResolveInternal(new TypeRegistration(resolveType), parameters, options);
+            return ResolveInternal(new TypeRegistration(resolveType), parameters, options, new ResolutionCache());
         }
 
         /// <summary>
@@ -1941,7 +1978,7 @@ namespace TinyIoC
         /// <exception cref="TinyIoCResolutionException">Unable to resolve the type.</exception>
         public object Resolve(Type resolveType, string name, NamedParameterOverloads parameters)
         {
-            return ResolveInternal(new TypeRegistration(resolveType, name), parameters, ResolveOptions.Default);
+            return ResolveInternal(new TypeRegistration(resolveType, name), parameters, ResolveOptions.Default, new ResolutionCache());
         }
 
         /// <summary>
@@ -1958,7 +1995,7 @@ namespace TinyIoC
         /// <exception cref="TinyIoCResolutionException">Unable to resolve the type.</exception>
         public object Resolve(Type resolveType, string name, NamedParameterOverloads parameters, ResolveOptions options)
         {
-            return ResolveInternal(new TypeRegistration(resolveType, name), parameters, options);
+            return ResolveInternal(new TypeRegistration(resolveType, name), parameters, options, new ResolutionCache());
         }
 
         /// <summary>
@@ -2096,7 +2133,7 @@ namespace TinyIoC
         /// <returns>Bool indicating whether the type can be resolved</returns>
         public bool CanResolve(Type resolveType)
         {
-            return CanResolveInternal(new TypeRegistration(resolveType), NamedParameterOverloads.Default, ResolveOptions.Default);
+            return CanResolveInternal(new TypeRegistration(resolveType), NamedParameterOverloads.Default, ResolveOptions.Default, new ResolutionCache());
         }
 
         /// <summary>
@@ -2109,7 +2146,7 @@ namespace TinyIoC
         /// <returns>Bool indicating whether the type can be resolved</returns>
         private bool CanResolve(Type resolveType, string name)
         {
-            return CanResolveInternal(new TypeRegistration(resolveType, name), NamedParameterOverloads.Default, ResolveOptions.Default);
+            return CanResolveInternal(new TypeRegistration(resolveType, name), NamedParameterOverloads.Default, ResolveOptions.Default, new ResolutionCache());
         }
 
         /// <summary>
@@ -2122,7 +2159,7 @@ namespace TinyIoC
         /// <returns>Bool indicating whether the type can be resolved</returns>
         public bool CanResolve(Type resolveType, ResolveOptions options)
         {
-            return CanResolveInternal(new TypeRegistration(resolveType), NamedParameterOverloads.Default, options);
+            return CanResolveInternal(new TypeRegistration(resolveType), NamedParameterOverloads.Default, options, new ResolutionCache());
         }
 
         /// <summary>
@@ -2136,7 +2173,7 @@ namespace TinyIoC
         /// <returns>Bool indicating whether the type can be resolved</returns>
         public bool CanResolve(Type resolveType, string name, ResolveOptions options)
         {
-            return CanResolveInternal(new TypeRegistration(resolveType, name), NamedParameterOverloads.Default, options);
+            return CanResolveInternal(new TypeRegistration(resolveType, name), NamedParameterOverloads.Default, options, new ResolutionCache());
         }
 
         /// <summary>
@@ -2152,7 +2189,7 @@ namespace TinyIoC
         /// <returns>Bool indicating whether the type can be resolved</returns>
         public bool CanResolve(Type resolveType, NamedParameterOverloads parameters)
         {
-            return CanResolveInternal(new TypeRegistration(resolveType), parameters, ResolveOptions.Default);
+            return CanResolveInternal(new TypeRegistration(resolveType), parameters, ResolveOptions.Default, new ResolutionCache());
         }
 
         /// <summary>
@@ -2169,7 +2206,7 @@ namespace TinyIoC
         /// <returns>Bool indicating whether the type can be resolved</returns>
         public bool CanResolve(Type resolveType, string name, NamedParameterOverloads parameters)
         {
-            return CanResolveInternal(new TypeRegistration(resolveType, name), parameters, ResolveOptions.Default);
+            return CanResolveInternal(new TypeRegistration(resolveType, name), parameters, ResolveOptions.Default, new ResolutionCache());
         }
 
         /// <summary>
@@ -2186,7 +2223,7 @@ namespace TinyIoC
         /// <returns>Bool indicating whether the type can be resolved</returns>
         public bool CanResolve(Type resolveType, NamedParameterOverloads parameters, ResolveOptions options)
         {
-            return CanResolveInternal(new TypeRegistration(resolveType), parameters, options);
+            return CanResolveInternal(new TypeRegistration(resolveType), parameters, options, new ResolutionCache());
         }
 
         /// <summary>
@@ -2204,7 +2241,7 @@ namespace TinyIoC
         /// <returns>Bool indicating whether the type can be resolved</returns>
         public bool CanResolve(Type resolveType, string name, NamedParameterOverloads parameters, ResolveOptions options)
         {
-            return CanResolveInternal(new TypeRegistration(resolveType, name), parameters, options);
+            return CanResolveInternal(new TypeRegistration(resolveType, name), parameters, options, new ResolutionCache());
         }
 
         /// <summary>
@@ -2694,7 +2731,7 @@ namespace TinyIoC
         /// <returns>IEnumerable</returns>
         public IEnumerable<object> ResolveAll(Type resolveType, bool includeUnnamed)
         {
-            return ResolveAllInternal(resolveType, includeUnnamed);
+            return ResolveAllInternal(resolveType, includeUnnamed, new ResolutionCache());
         }
 
         /// <summary>
@@ -2736,7 +2773,7 @@ namespace TinyIoC
         /// <param name="input">Object to "build up"</param>
         public void BuildUp(object input)
         {
-            BuildUpInternal(input, ResolveOptions.Default);
+            BuildUpInternal(input, ResolveOptions.Default, new ResolutionCache());
         }
 
         /// <summary>
@@ -2746,7 +2783,7 @@ namespace TinyIoC
         /// <param name="resolveOptions">Resolve options to use</param>
         public void BuildUp(object input, ResolveOptions resolveOptions)
         {
-            BuildUpInternal(input, resolveOptions);
+            BuildUpInternal(input, resolveOptions, new ResolutionCache());
         }
 #endregion
 #endregion
@@ -2882,7 +2919,7 @@ namespace TinyIoC
             {
                 try
                 {
-                    return container.ConstructType(requestedType, this.registerImplementation, Constructor, parameters, options);
+                    return container.ConstructType(requestedType, this.registerImplementation, Constructor, parameters, options, new ResolutionCache());
                 }
                 catch (TinyIoCResolutionException ex)
                 {
@@ -3244,7 +3281,7 @@ namespace TinyIoC
 
                 lock (SingletonLock)
                     if (_Current == null)
-                        _Current = container.ConstructType(requestedType, this.registerImplementation, Constructor, options);
+                        _Current = container.ConstructType(requestedType, this.registerImplementation, Constructor, options, new ResolutionCache());
 
                 return _Current;
             }
@@ -3378,7 +3415,7 @@ namespace TinyIoC
                     current = _LifetimeProvider.GetObject();
                     if (current == null)
                     {
-                        current = container.ConstructType(requestedType, this.registerImplementation, Constructor, options);
+                        current = container.ConstructType(requestedType, this.registerImplementation, Constructor, options, new ResolutionCache());
                         _LifetimeProvider.SetObject(current);
                     }
                 }
@@ -3676,7 +3713,7 @@ namespace TinyIoC
             return new MultiInstanceFactory(registerType, registerImplementation);
         }
 
-        private bool CanResolveInternal(TypeRegistration registration, NamedParameterOverloads parameters, ResolveOptions options)
+        private bool CanResolveInternal(TypeRegistration registration, NamedParameterOverloads parameters, ResolveOptions options, ResolutionCache resolutionCache)
         {
             if (parameters == null)
                 throw new ArgumentNullException("parameters");
@@ -3691,9 +3728,9 @@ namespace TinyIoC
                     return true;
 
                 if (factory.Constructor == null)
-                    return GetBestConstructor(factory.CreatesType, parameters, options) != null;
+                    return GetBestConstructor(factory.CreatesType, parameters, options, resolutionCache) != null;
                 else
-                    return CanConstruct(factory.Constructor, parameters, options);
+                    return CanConstruct(factory.Constructor, parameters, options, resolutionCache);
             }
 
 #if RESOLVE_OPEN_GENERICS
@@ -3706,9 +3743,9 @@ namespace TinyIoC
                         return true;
 
                     if (factory.Constructor == null)
-                        return GetBestConstructor(factory.CreatesType, parameters, options) != null;
+                        return GetBestConstructor(factory.CreatesType, parameters, options, resolutionCache) != null;
                     else
-                        return CanConstruct(factory.Constructor, parameters, options);
+                        return CanConstruct(factory.Constructor, parameters, options, resolutionCache);
                 }
             }
 #endif
@@ -3716,7 +3753,7 @@ namespace TinyIoC
             // Fail if requesting named resolution and settings set to fail if unresolved
             // Or bubble up if we have a parent
             if (!string.IsNullOrEmpty(name) && options.NamedResolutionFailureAction == NamedResolutionFailureActions.Fail)
-                return (_Parent != null) ? _Parent.CanResolveInternal(registration, parameters, options) : false;
+                return (_Parent != null) ? _Parent.CanResolveInternal(registration, parameters, options, resolutionCache) : false;
 
             // Attempted unnamed fallback container resolution if relevant and requested
             if (!string.IsNullOrEmpty(name) && options.NamedResolutionFailureAction == NamedResolutionFailureActions.AttemptUnnamedResolution)
@@ -3726,7 +3763,7 @@ namespace TinyIoC
                     if (factory.AssumeConstruction)
                         return true;
 
-                    return GetBestConstructor(factory.CreatesType, parameters, options) != null;
+                    return GetBestConstructor(factory.CreatesType, parameters, options, resolutionCache) != null;
                 }
             }
 
@@ -3741,11 +3778,11 @@ namespace TinyIoC
             // Attempt unregistered construction if possible and requested
             // If we cant', bubble if we have a parent
             if ((options.UnregisteredResolutionAction == UnregisteredResolutionActions.AttemptResolve) || (checkType.IsGenericType() && options.UnregisteredResolutionAction == UnregisteredResolutionActions.GenericsOnly))
-                return (GetBestConstructor(checkType, parameters, options) != null) ? true : (_Parent != null) ? _Parent.CanResolveInternal(registration, parameters, options) : false;
+                return (GetBestConstructor(checkType, parameters, options, resolutionCache) != null) ? true : (_Parent != null) ? _Parent.CanResolveInternal(registration, parameters, options, resolutionCache) : false;
 
             // Bubble resolution up the container tree if we have a parent
             if (_Parent != null)
-                return _Parent.CanResolveInternal(registration, parameters, options);
+                return _Parent.CanResolveInternal(registration, parameters, options, new ResolutionCache());
 
             return false;
         }
@@ -3828,7 +3865,7 @@ namespace TinyIoC
             return _Parent.GetParentObjectFactory(registration);
         }
 
-        private object ResolveInternal(TypeRegistration registration, NamedParameterOverloads parameters, ResolveOptions options)
+        private object ResolveInternal(TypeRegistration registration, NamedParameterOverloads parameters, ResolveOptions options, ResolutionCache resolutionCache)
         {
             ObjectFactoryBase factory;
 
@@ -3928,7 +3965,7 @@ namespace TinyIoC
             if ((options.UnregisteredResolutionAction == UnregisteredResolutionActions.AttemptResolve) || (registration.Type.IsGenericType() && options.UnregisteredResolutionAction == UnregisteredResolutionActions.GenericsOnly))
             {
                 if (!registration.Type.IsAbstract() && !registration.Type.IsInterface())
-                    return ConstructType(null, registration.Type, parameters, options);
+                    return ConstructType(null, registration.Type, parameters, options, resolutionCache);
             }
 
             // Unable to resolve - throw
@@ -4037,15 +4074,21 @@ namespace TinyIoC
             return genericResolveAllMethod.Invoke(this, new object[] { false });
         }
 
-        private bool CanConstruct(ConstructorInfo ctor, NamedParameterOverloads parameters, ResolveOptions options)
+        private bool CanConstruct(ConstructorInfo ctor, NamedParameterOverloads parameters, ResolveOptions options, ResolutionCache resolutionCache)
         {
             if (parameters == null)
                 throw new ArgumentNullException("parameters");
 
+            if (resolutionCache.TryGetCanConstruct(ctor, out var canConstruct))
+                return canConstruct;
+
             foreach (var parameter in ctor.GetParameters())
             {
                 if (string.IsNullOrEmpty(parameter.Name))
+                {
+                    resolutionCache.SetCanConstruct(ctor, false);
                     return false;
+                }
 
                 var isParameterOverload = parameters.ContainsKey(parameter.Name);
 
@@ -4054,19 +4097,29 @@ namespace TinyIoC
                 //#else
                 if (parameter.ParameterType.IsPrimitive() && !isParameterOverload)
                     //#endif
+                {
+                    resolutionCache.SetCanConstruct(ctor, false);
                     return false;
+                }
 
-                if (!isParameterOverload && !CanResolveInternal(new TypeRegistration(parameter.ParameterType), NamedParameterOverloads.Default, options))
+                if (!isParameterOverload && !CanResolveInternal(new TypeRegistration(parameter.ParameterType), NamedParameterOverloads.Default, options, resolutionCache))
+                {
+                    resolutionCache.SetCanConstruct(ctor, false);
                     return false;
+                }
             }
 
+            resolutionCache.SetCanConstruct(ctor, true);
             return true;
         }
 
-        private ConstructorInfo GetBestConstructor(Type type, NamedParameterOverloads parameters, ResolveOptions options)
+        private ConstructorInfo GetBestConstructor(Type type, NamedParameterOverloads parameters, ResolveOptions options, ResolutionCache resolutionCache)
         {
             if (parameters == null)
                 throw new ArgumentNullException("parameters");
+
+            if (resolutionCache.TryGetBestConstructor(type, out var bestConstructor))
+                return bestConstructor;
 
             //#if NETFX_CORE
             //			if (type.GetTypeInfo().IsValueType)
@@ -4081,29 +4134,33 @@ namespace TinyIoC
 
             foreach (var ctor in ctors)
             {
-                if (this.CanConstruct(ctor, parameters, options))
+                if (this.CanConstruct(ctor, parameters, options, resolutionCache))
+                {
+                    resolutionCache.SetBestConstructor(type, ctor);
                     return ctor;
+                }
             }
 
+            resolutionCache.SetBestConstructor(type, null);
             return null;
         }
 
-        private object ConstructType(Type requestedType, Type implementationType, ResolveOptions options)
+        private object ConstructType(Type requestedType, Type implementationType, ResolveOptions options, ResolutionCache resolutionCache)
         {
-            return ConstructType(requestedType, implementationType, null, NamedParameterOverloads.Default, options);
+            return ConstructType(requestedType, implementationType, null, NamedParameterOverloads.Default, options, resolutionCache);
         }
 
-        private object ConstructType(Type requestedType, Type implementationType, ConstructorInfo constructor, ResolveOptions options)
+        private object ConstructType(Type requestedType, Type implementationType, ConstructorInfo constructor, ResolveOptions options, ResolutionCache resolutionCache)
         {
-            return ConstructType(requestedType, implementationType, constructor, NamedParameterOverloads.Default, options);
+            return ConstructType(requestedType, implementationType, constructor, NamedParameterOverloads.Default, options, resolutionCache);
         }
 
-        private object ConstructType(Type requestedType, Type implementationType, NamedParameterOverloads parameters, ResolveOptions options)
+        private object ConstructType(Type requestedType, Type implementationType, NamedParameterOverloads parameters, ResolveOptions options, ResolutionCache resolutionCache)
         {
-            return ConstructType(requestedType, implementationType, null, parameters, options);
+            return ConstructType(requestedType, implementationType, null, parameters, options, resolutionCache);
         }
 
-        private object ConstructType(Type requestedType, Type implementationType, ConstructorInfo constructor, NamedParameterOverloads parameters, ResolveOptions options)
+        private object ConstructType(Type requestedType, Type implementationType, ConstructorInfo constructor, NamedParameterOverloads parameters, ResolveOptions options, ResolutionCache resolutionCache)
         {
             var typeToConstruct = implementationType;
 
@@ -4119,7 +4176,7 @@ namespace TinyIoC
               // if we can't construct any then get the constructor
               // with the least number of parameters so we can throw a meaningful
               // resolve exception
-              constructor = GetBestConstructor(typeToConstruct, parameters, options) ?? TinyIoCReflectionCache.GetUsableConstructors(typeToConstruct).LastOrDefault();
+              constructor = GetBestConstructor(typeToConstruct, parameters, options, resolutionCache) ?? TinyIoCReflectionCache.GetUsableConstructors(typeToConstruct).LastOrDefault();
             }
 
             if (constructor == null)
@@ -4139,7 +4196,8 @@ namespace TinyIoC
 																						        ResolveInternal(
 																								        new TypeRegistration(currentParam.ParameterType),
 																								        NamedParameterOverloads.Default,
-																								        options);
+																								        options,
+																									resolutionCache);
 				        }
                 catch (TinyIoCResolutionException ex)
                 {
@@ -4202,7 +4260,7 @@ namespace TinyIoC
         }
 #endif
 
-        private void BuildUpInternal(object input, ResolveOptions resolveOptions)
+        private void BuildUpInternal(object input, ResolveOptions resolveOptions, ResolutionCache resolutionCache)
         {
             //#if NETFX_CORE
             //			var properties = from property in input.GetType().GetTypeInfo().DeclaredProperties
@@ -4220,7 +4278,7 @@ namespace TinyIoC
                 {
                     try
                     {
-                        property.SetValue(input, ResolveInternal(new TypeRegistration(property.PropertyType), NamedParameterOverloads.Default, resolveOptions), null);
+                        property.SetValue(input, ResolveInternal(new TypeRegistration(property.PropertyType), NamedParameterOverloads.Default, resolveOptions, resolutionCache), null);
                     }
                     catch (TinyIoCResolutionException)
                     {
@@ -4240,14 +4298,14 @@ namespace TinyIoC
             return registrations.Concat(_Parent.GetParentRegistrationsForType(resolveType));
         }
 
-        private IEnumerable<object> ResolveAllInternal(Type resolveType, bool includeUnnamed)
+        private IEnumerable<object> ResolveAllInternal(Type resolveType, bool includeUnnamed, ResolutionCache resolutionCache)
         {
             var registrations = _RegisteredTypes.Keys.Where(tr => tr.Type == resolveType).Concat(GetParentRegistrationsForType(resolveType)).Distinct();
 
             if (!includeUnnamed)
                 registrations = registrations.Where(tr => tr.Name != string.Empty);
 
-            return registrations.Select(registration => this.ResolveInternal(registration, NamedParameterOverloads.Default, ResolveOptions.Default));
+            return registrations.Select(registration => this.ResolveInternal(registration, NamedParameterOverloads.Default, ResolveOptions.Default, resolutionCache));
         }
 
         private static bool IsValidAssignment(Type registerType, Type registerImplementation)

--- a/tests/TinyIoc.Benchmarks/ComplexHierarchyBenchmark.cs
+++ b/tests/TinyIoc.Benchmarks/ComplexHierarchyBenchmark.cs
@@ -1,0 +1,135 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace TinyIoc.Benchmarks
+{
+	
+#if NET48 //These work on either platform but no point running them twice
+	[SimpleJob(BenchmarkDotNet.Jobs.RuntimeMoniker.Net48)]
+	[SimpleJob(BenchmarkDotNet.Jobs.RuntimeMoniker.Net461)]
+#endif
+#if NETCOREAPP3_1_OR_GREATER // These don't seem to work in a FX app
+    [SimpleJob(BenchmarkDotNet.Jobs.RuntimeMoniker.NetCoreApp31)]
+    [RyuJitX86Job]
+#endif
+#if NET48 //These don't seem to work in a .net core app
+	[RyuJitX64Job]
+	[MonoJob]
+#endif
+    [MemoryDiagnoser]
+    public class ComplexHierarchyBenchmark
+    {
+	    [BenchmarkCategory("ComplexHierarchy"), Benchmark]
+	    public DepA Original_DeepHierarchy()
+	    {
+		    var retVal = new TinyIoC.Original.TinyIoCContainer();
+		    return retVal.Resolve<DepA>();
+	    }
+	    
+	    [BenchmarkCategory("ComplexHierarchy"), Benchmark]
+	    public DepA New_DeepHierarchy()
+	    {
+		    var retVal = new TinyIoC.TinyIoCContainer();
+		    return retVal.Resolve<DepA>();
+	    }
+    }
+
+    public class DepA
+    {
+	    public DepA(DepB depB, DepC depC, DepD depD, DepE depE, DepF depF, DepG depG, DepH depH, DepI depI, DepJ depJ, DepK depK, DepL depL, DepM depM, DepN depN, DepO depO, DepP depP, DepQ depQ, DepR depR, DepS depS, DepT depT) { }
+    }
+    
+    public class DepB
+    {
+	    public DepB(DepC depC, DepD depD, DepE depE, DepF depF, DepG depG, DepH depH, DepI depI, DepJ depJ, DepK depK, DepL depL, DepM depM, DepN depN, DepO depO, DepP depP, DepQ depQ, DepR depR, DepS depS, DepT depT) { }
+    }
+
+    public class DepC
+    {
+	    public DepC(DepD depD, DepE depE, DepF depF, DepG depG, DepH depH, DepI depI, DepJ depJ, DepK depK, DepL depL, DepM depM, DepN depN, DepO depO, DepP depP, DepQ depQ, DepR depR, DepS depS, DepT depT) { }
+    }
+
+    
+    public class DepD
+    {
+	    public DepD(DepE depE, DepF depF, DepG depG, DepH depH, DepI depI, DepJ depJ, DepK depK, DepL depL, DepM depM, DepN depN, DepO depO, DepP depP, DepQ depQ, DepR depR, DepS depS, DepT depT) { }
+    }
+    
+    public class DepE
+    {
+	    public DepE(DepF depF, DepG depG, DepH depH, DepI depI, DepJ depJ, DepK depK, DepL depL, DepM depM, DepN depN, DepO depO, DepP depP, DepQ depQ, DepR depR, DepS depS, DepT depT) { }
+    }
+    
+    public class DepF
+    {
+	    public DepF(DepG depG, DepH depH, DepI depI, DepJ depJ, DepK depK, DepL depL, DepM depM, DepN depN, DepO depO, DepP depP, DepQ depQ, DepR depR, DepS depS, DepT depT) { }
+    }
+    
+    public class DepG
+    {
+	    public DepG(DepH depH, DepI depI, DepJ depJ, DepK depK, DepL depL, DepM depM, DepN depN, DepO depO, DepP depP, DepQ depQ, DepR depR, DepS depS, DepT depT) { }
+    }
+    
+    public class DepH
+    {
+	    public DepH(DepI depI, DepJ depJ, DepK depK, DepL depL, DepM depM, DepN depN, DepO depO, DepP depP, DepQ depQ, DepR depR, DepS depS, DepT depT) { }
+    }
+    
+    public class DepI
+    {
+	    public DepI(DepJ depJ, DepK depK, DepL depL, DepM depM, DepN depN, DepO depO, DepP depP, DepQ depQ, DepR depR, DepS depS, DepT depT) { }
+    }
+    
+    public class DepJ
+    {
+	    public DepJ(DepK depK, DepL depL, DepM depM, DepN depN, DepO depO, DepP depP, DepQ depQ, DepR depR, DepS depS, DepT depT) { }
+    }
+    
+    public class DepK
+    {
+	    public DepK(DepL depL, DepM depM, DepN depN, DepO depO, DepP depP, DepQ depQ, DepR depR, DepS depS, DepT depT) { }
+    }
+    
+    public class DepL
+    {
+	    public DepL(DepM depM, DepN depN, DepO depO, DepP depP, DepQ depQ, DepR depR, DepS depS, DepT depT) { }
+    }
+    
+    public class DepM
+    {
+	    public DepM(DepN depN, DepO depO, DepP depP, DepQ depQ, DepR depR, DepS depS, DepT depT) { }
+    }
+    
+    public class DepN
+    {
+	    public DepN(DepO depO, DepP depP, DepQ depQ, DepR depR, DepS depS, DepT depT) { }
+    }
+    
+    public class DepO
+    {
+	    public DepO(DepP depP, DepQ depQ, DepR depR, DepS depS, DepT depT) { }
+    }
+    
+    public class DepP
+    {
+	    public DepP(DepQ depQ, DepR depR, DepS depS, DepT depT) { }
+    }
+    
+    public class DepQ
+    {
+	    public DepQ(DepR depR, DepS depS, DepT depT) { }
+    }
+    
+    public class DepR
+    {
+	    public DepR(DepS depS, DepT depT) { }
+    }
+    
+    public class DepS
+    {
+	    public DepS(DepT depT) { }
+    }
+    
+    public class DepT
+    {
+    }
+}


### PR DESCRIPTION
Hi, sorry for the wall of text. I've tried to break this into a few sections and for each one show how the performance problem manifests. I felt that it was necessary to understand the reasoning for the approach at the end. **If you prefer to skip to the end, the TL;DR is that "CanResolve, Resolve, and ResolveAll recalculate the same values repeatedly for some structures, causing multiple second delays."**

When resolving an object from TinyIoC, before resolution, it first needs to verify that it's dependencies can be resolved. The way it handles this is to reflect a list of all constructors from the dependency and to go through them checking to see if all parameters for the constructor can themselves be constructed. This continues recursively, until a constructor that can be satisfied can be found for each dependency and the original object. After finding that an object can be resolved, TinyIoC then begins construction, a process that requires performing the previous calculation again to determine the correct constructor, as no data is cached.

This alone is unnoticable, though it is a small example of the problem that appears to grow at scale if using large dependency trees, ResolveAll, or the presence of constructors that cannot be successfully resolved. In all three cases, the performance problem itself is a result of repeated recalculation of constructability for the same types.

**Large Dependency Tree**

Consider the below as an example of a small "large dependency tree".

```
class Foo
{
    public Foo(Bar bar, Baz baz, Qux qux) { }
}

class Bar
{
    public Bar(Baz baz, Qux qux) { }
}

class Baz
{
    public Baz(Qux qux) { }
}

class Qux { }
```

Due to the lack of caching, a request to resolve Foo leads to the following:

 - Check if Foo can be resolved
   - Check if Bar can be resolved
     - Check if Baz can be resolved
       - Check if Qux can be resolved
     - Check if Qux can be resolved
   - Check if Baz can be resolved
     - Check if Quz can be resolved
   - Check if Qux can be resolved

This totals 1 check for Bar, 2 for Baz, and 3 for Qux. For a total of 6 tests for eligability. As the same logic must be performed again during the resolution stage, after we are certain that a constructor chain exists, the effective number of tests is doubled, coming in at 12.

**Multiple Resolutions**

Another possibility is that we have a number of event handlers all of which need to be resolved and which share dependencies, such as one might expect of a database or logger.

```
public class FooEventHandler1 : IFooEventHandler
{
    public FooEventHandler1(Foo foo) { }
}

public class FooEventHandler2 : IFooEventHandler
{
    public FooEventHandler2(Foo foo) { }
}

public class FooEventHandler3 : IFooEventHandler
{
    public FooEventHandler3(Foo foo) { }
}

public class FooEventHandler4 : IFooEventHandler
{
    public FooEventHandler4(Foo foo) { }
}
```

Assuming the above classes are all registered with TinyIoC as IFooEventHandler, then a call to `ResolveAll<IFooEventHandler>()` would check that the common dependency Foo could be resolved on each handler resolution, for a total of four checks of the same type.

If, continuing with the class definitions from the previous example, we remember that each check of Foo causes 6 tests to occur, followed by another 6 during the actual construction of the object, then we could expect this call to ResolveAll to cause 6 * (4 + 1) test for a total of 30 tests.

**Unusable Constructors**

There's still one more case that leads to test-multiplication: if the most preferable constructor (the one requiring the most arguments) has a dependency that cannot be resolved via IoC, such as for the case where it is generated by a factory or a deserializer.

```
class Foo
{
    public Foo(Bar bar, Baz baz, Qux qux, Bang bang) { }

    public Foo(Bar bar, Baz baz, Qux qux) { }
}
```

If we were to update our original Foo class to now have a constructor that requires an unresolvable type "Bang", the effect is that we manage to double the test performed: TinyIoC will test Bar, Baz, and Qux successfully before finding that Bang cannot be constructed. With the knowledge that this constructor cannot be resolved, TinyIoC will then try the next constructor in line, attempting a second time to resolve Bar, Baz, and Qux again, not remembering that we've already found them to be resolvable. The effect here is (4 + 1) * (6 + 6 + 1): Each of the 4 IFooEventHandlers requiring the chain be tested, followed by one final test in during construction in order to find the appropriate constructor. The result, given these simplistic classes and their hierarchy, is 65 tests even though there are only 10 constructors defined between the 9 classes.

This last case is the easiest to handle, as the addition of an attribute on the constructor can tell the TinyIoC which constructor to use, but that only works for first-party code and in many cases creates an awareness of TinyIoC from the objects being constructed that it did not already have.

**Summary**

Given these three very real and very common patterns, the effective number of checks can be in the millions in a larger codebase, taking 20-30 seconds per request, depending on the number of handlers needing construction.

**Resolution**

The resolution for this issue is rather straightforward: after testing a Type or constructor, the result should be stored so that it does not have to be recalculated.

My first approach was to store the value within TinyIoC so that separate calls to Resolve or ResolveAll would be able to use a common cache. This turned out to be non-practical though, since calls to these methods can specify extra parameters that affect resolution, such as named resolution. Using a global cache would require that either named resolutions were not cached or that logic was complicated to cache them while preventing a memory leak.

Given that limitation, I took the approach of creating a cache that gets passed around internally over the lifetime of the Resolve call and gets populated as tests occur. This means that repeated calls to Resolve will perform the same checks, but that each check will only be performed a single time within a Resolve, changing what could be quadradic growth of time into linear time.

I verified that this fixed the issue that I was seeing and I also ran the unit tests to make sure that this did not introduce a regression.